### PR TITLE
Fix issue with encoded urls

### DIFF
--- a/src/ios/PreviewAnyFile.swift
+++ b/src/ios/PreviewAnyFile.swift
@@ -268,7 +268,7 @@ import CoreServices
 
        //if the file not exist by read the url, so try again to get the file by reading base64 string
         if !FileManager.default.fileExists(atPath: itemUrl!.path) {
-                   itemUrl = Foundation.URL(string: myUrl);
+                   itemUrl = Foundation.URL(string: url);
         }
         
         if FileManager.default.fileExists(atPath: itemUrl!.path) {

--- a/src/ios/PreviewAnyFile.swift
+++ b/src/ios/PreviewAnyFile.swift
@@ -266,13 +266,8 @@ import CoreServices
         let  url = myUrl.addingPercentEncoding(withAllowedCharacters:NSCharacterSet.urlQueryAllowed)!;
         var itemUrl: URL? = Foundation.URL(string: url);
 
-       //if the file not exist by read the url, so try again to get the file by reading base64 string
-        if !FileManager.default.fileExists(atPath: itemUrl!.path) {
-                   itemUrl = Foundation.URL(string: url);
-        }
-        
         if FileManager.default.fileExists(atPath: itemUrl!.path) {
-
+            
             if(itemUrl?.scheme == nil){
                 itemUrl = Foundation.URL(string: "file://\(url)");
             }


### PR DESCRIPTION
I noticed that my app was crashing when the url contains whitespaces