### PR TITLE
complete android file paths

### DIFF
--- a/src/android/xml/file_paths.xml
+++ b/src/android/xml/file_paths.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path name="my_images" path="." />
-    <external-files-path name="cache_files" path="/" />
-    <cache-path name="cache_files" path="/" />
+    <!-- cordova.file.dataDirectory -->
+    <files-path name="files" path="." />
+    <!-- cordova.file.cacheDirectory -->
+    <cache-path name="cache" path="." />
+    <!-- cordova.file.externalDataDirectory -->
+    <external-files-path name="external-files" path="." />
+    <!-- cordova.file.externalCacheDirectory -->
+    <external-cache-path name="external-cache" path="." />
+    <!-- cordova.file.externalRootDirectory -->
+    <external-path name="external" path="." />
 </paths>


### PR DESCRIPTION
I noticed that files located in `cordova.file.cacheDirectory` in Android cannot be previewed with the method `previewPath`. The error is `Failed to find configured root that contains /[...]`.

I updated the paths in file_paths.xml to match all known cordova paths.

Theses paths are taken from [Cordova File Opener Plugin](https://github.com/pwlin/cordova-plugin-file-opener2/blob/master/src/android/res/xml/opener_paths.xml).

To test: download and save a file in cordova.file.cacheDirectory and try to preview it.